### PR TITLE
teiidrhq-29:

### DIFF
--- a/teiid-rhq-plugin/src/main/java/org/teiid/rhq/admin/TeiidModuleView.java
+++ b/teiid-rhq-plugin/src/main/java/org/teiid/rhq/admin/TeiidModuleView.java
@@ -418,7 +418,7 @@ public class TeiidModuleView implements PluginConstants {
 
 		Address address = DmrUtil.getTeiidAddress();
 		Result result;
-		if (vdbName!=null){
+		if (vdbName==null){
 			result = executeOperation(connection,
 					Platform.Operations.GET_REQUESTS, address, null);
 		}else{


### PR DESCRIPTION
Fix for Platform level metrics. Query count logic was not checking for the vdb-name correctly and tried to execute the vdb request count which caused a missing parameter error (vdb-name). 